### PR TITLE
Hall版も加えた

### DIFF
--- a/src/main/java/smnow/Attendance.java
+++ b/src/main/java/smnow/Attendance.java
@@ -5,6 +5,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Created by yusuke on 7/25/14.
@@ -26,12 +28,18 @@ import java.util.Arrays;
 public final class Attendance {
     static Logger logger = LoggerFactory.getLogger(Attendance.class);
 
-    private final AttendanceListener listener;
+    private final List<AttendanceListener> listeners;
     static final String ATTENDANCE_HISTORY = ".attendanceHistory";
     static final String IS_AT_SAMURAISM = ".isAtSamuraism";
 
     Attendance(AttendanceListener listener) {
-        this.listener = listener;
+        List<AttendanceListener> list = new ArrayList<>();
+        list.add(listener);
+        this.listeners = Collections.unmodifiableList(list);
+    }
+
+    Attendance(AttendanceListener... listeners) {
+        this.listeners = Arrays.asList(listeners);
     }
 
     void recordAttendance(Person person, boolean latestAttendance) {
@@ -53,14 +61,14 @@ public final class Attendance {
             if (latestAttendance) {
                 logger.debug("{} entered", person.name);
                 isAtSamuraism = true;
-                listener.entered(person);
+                listeners.forEach(listener -> listener.entered(person));
             }
         } else {
             // 3回連続で不在状態を検知したら不在を通知
             if (strings.stream().allMatch(e -> e.equals("false"))) {
                 logger.debug("{} left", person.name);
                 isAtSamuraism = false;
-                listener.left(person);
+                listeners.forEach(listener -> listener.left(person));
             }
         }
 

--- a/src/main/java/smnow/Main.java
+++ b/src/main/java/smnow/Main.java
@@ -2,6 +2,7 @@ package smnow;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import smnow.hall.HallListener;
 import twitter4j.Twitter;
 import twitter4j.TwitterException;
 import twitter4j.TwitterFactory;
@@ -28,41 +29,14 @@ import java.time.format.DateTimeFormatter;
  */
 public class Main {
     static Logger logger = LoggerFactory.getLogger(Main.class);
-    private static DateTimeFormatter format = DateTimeFormatter.ofPattern("HH:mm");
-
 
     public static void main(String[] args) {
         Person[] persons = Person.load();
-        Twitter twitter = TwitterFactory.getSingleton();
         boolean dryRun = false;
 
-        Attendance attendance = new Attendance(new AttendanceListener() {
-            @Override
-            public void entered(Person person) {
-                String message = String.format("%s %s ズムなう", LocalDateTime.now().format(format), person.name);
-                logger.debug(message);
-                if (!dryRun) {
-                    try {
-                        twitter.updateStatus(message);
-                    } catch (TwitterException e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-
-            @Override
-            public void left(Person person) {
-                String message = String.format("%s %s ズムあうと", LocalDateTime.now().format(format), person.name);
-                logger.debug(message);
-                if (!dryRun) {
-                    try {
-                        twitter.updateStatus(message);
-                    } catch (TwitterException e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        });
+        Attendance attendance = new Attendance(
+                new TwitterListener(dryRun),
+                new HallListener(dryRun));
         while (true) {
             for (Person person : persons) {
                 attendance.recordAttendance(person, person.isAtSamuraism());

--- a/src/main/java/smnow/SMStatus.java
+++ b/src/main/java/smnow/SMStatus.java
@@ -1,0 +1,43 @@
+package smnow;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Copyright 2014Shinya Mochida
+ * <p>
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public enum SMStatus {
+
+    SMOUT {
+        @Override
+        public String message(Person person) {
+            return String.format("%s %s ズムあうと",
+                    LocalDateTime.now(ZoneId.of(TOKYO)).format(FORMAT), person.name);
+        }
+    }, SMIN {
+        @Override
+        public String message(Person person) {
+            return String.format("%s %s ズムなう",
+                    LocalDateTime.now(ZoneId.of(TOKYO)).format(FORMAT), person.name);
+        }
+    };
+
+    private static final String TOKYO = "Asia/Tokyo";
+
+    private static DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("HH:mm");
+
+    abstract public String message(Person person);
+}

--- a/src/main/java/smnow/TwitterListener.java
+++ b/src/main/java/smnow/TwitterListener.java
@@ -1,0 +1,65 @@
+package smnow;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Copyright 2014Shinya Mochida
+ * <p>
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class TwitterListener implements AttendanceListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(TwitterListener.class);
+
+    private final boolean dryRun;
+
+    private final Twitter twitter;
+
+    public TwitterListener(boolean dryRun) {
+        this.dryRun = dryRun;
+        this.twitter = TwitterFactory.getSingleton();
+    }
+
+    @Override
+    public void entered(Person person) {
+        String message = SMStatus.SMIN.message(person);
+        logger.debug(message);
+        if (!dryRun) {
+            try {
+                twitter.updateStatus(message);
+            } catch (TwitterException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void left(Person person) {
+        String message = SMStatus.SMOUT.message(person);
+        logger.debug(message);
+        if (!dryRun) {
+            try {
+                twitter.updateStatus(message);
+            } catch (TwitterException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/smnow/hall/HallListener.java
+++ b/src/main/java/smnow/hall/HallListener.java
@@ -1,0 +1,92 @@
+package smnow.hall;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import smnow.AttendanceListener;
+import smnow.GlobalProp;
+import smnow.Person;
+import smnow.SMStatus;
+
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Optional;
+
+/**
+ * Copyright 2014Shinya Mochida
+ * <p>
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class HallListener implements AttendanceListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HallListener.class);
+
+    private static final String SMNW = "ズムなう";
+
+    private static final String HALL_API_URL = "https://hall.com/api/1/services/generic/";
+
+    private static final String HALL_KEY = "hall.key";
+
+    private final boolean dryRun;
+
+    private final Optional<String> hallKey;
+
+    public HallListener(boolean dryRun) {
+        this.dryRun = dryRun;
+        this.hallKey = Optional.ofNullable(GlobalProp.getProperty(HALL_KEY));
+    }
+
+    @Override
+    public void entered(Person person) {
+        if (!dryRun)
+            sendMessage(SMStatus.SMIN.message(person));
+    }
+
+    @Override
+    public void left(Person person) {
+        if (!dryRun)
+            sendMessage(SMStatus.SMOUT.message(person));
+    }
+
+    private void sendMessage(String message) {
+        hallKey.ifPresent(key -> {
+            HttpURLConnection connection = null;
+            try {
+                URL url = new URL(HALL_API_URL + key);
+                connection = (HttpURLConnection) url.openConnection();
+                connection.setDoOutput(true);
+                connection.setRequestMethod("POST");
+                connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
+
+                PrintWriter writer = new PrintWriter(connection.getOutputStream());
+                writer.print(toJson(message));
+                writer.flush();
+
+                int responseCode = connection.getResponseCode();
+                if (responseCode != 201) throw new Exception("エラーが返されたわー : " + responseCode);
+            } catch (Throwable e) {
+                e.printStackTrace();
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+        });
+    }
+
+    String toJson(String message) {
+        return "{\"title\":\"" + SMNW + "\",\"message\":\"" +
+                message.replaceAll("\"", "\\\\\"") +
+                "\"}";
+    }
+}

--- a/src/main/java/smnow/hall/README.md
+++ b/src/main/java/smnow/hall/README.md
@@ -1,0 +1,8 @@
+Hallバージョン
+===
+
+```
+$ vi smnow.properties  
+\# hallのapi keyを入力
+hall.key=abcdefghijk1234567890
+```

--- a/src/test/java/smnow/hall/HallListenerTest.java
+++ b/src/test/java/smnow/hall/HallListenerTest.java
@@ -1,0 +1,33 @@
+package smnow.hall;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Copyright 2014Shinya Mochida
+ * <p>
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class HallListenerTest {
+
+    @Test
+    public void testToJson () {
+        HallListener listener = new HallListener(true);
+        String json = listener.toJson("this \"test\" is a test");
+        String expected = "{\"title\":\"ズムなう\",\"message\":\"this \\\"test\\\" is a test\"}";
+
+        assertThat(json, is(expected));
+    }
+}


### PR DESCRIPTION
- Hall版を加えた
- 上記の追加に合わせて、Twitterの処理部分をTwitterListenerクラスにわけた
- 退出と入室のメッセージがほぼ同じフォーマットだったし、メッセージ用のSMStatusっていうクラスを追加した
- Listenerが複数あってもいいように、AttendanceのAttendanceListenerの持ち方を`List<AttendanceListener>`にした
# Hall版

smnow.propertiesに

```
hall.key=abcdef1234567890
```

を追加すれば多分動く
